### PR TITLE
acu66732 fix child_account update href 

### DIFF
--- a/lib/right_api_client/resource_detail.rb
+++ b/lib/right_api_client/resource_detail.rb
@@ -97,7 +97,12 @@ module RightApi
 
       # Add update method to relevant resources
       define_instance_method('update') do |*args|
-        client.do_put(href, *args)
+        if resource_type == 'account' # HACK: handle child_account update specially
+          update_href = href.sub(/account/, 'child_account')
+          client.do_put(update_href, *args)
+        else
+          client.do_put(href, *args)
+        end
       end
 
       # Add show method to relevant resources


### PR DESCRIPTION
This needs to be handled specially because there is no real ChildAccount resource.
On the other hand, the API does not support Account#update either.
Therefore, we can pretend that we are always dealing with a ChildAccount resource.

Usage:
child_account = @client.child_accounts.index.last
child_account.update(:name => "Account 62840")
