### PR TITLE
NaN results from monitoring metrics cause JSON parser error

### DIFF
--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -301,7 +301,7 @@ module RightApi
               # therefore, ResourceDetail objects needs to be returned
               if response.code == 200 && response.headers[:content_type].index('rightscale')
                 resource_type = get_resource_type(response.headers[:content_type])
-                data = JSON.parse(response)
+                data = JSON.parse(response, :allow_nan => true)
                 # Resource_tag is returned after querying tags.by_resource or tags.by_tags.
                 # You cannot do a show on a resource_tag, but that is basically what we want to do
                 data.map { |obj|


### PR DESCRIPTION
``` ruby
r,p,data = client.do_get '/api/clouds/####/instances/######/monitoring_metrics/load:load/data?start=-60&end=0'
JSON::ParserError: 209: unexpected token at 'NaN,NaN],"variable":"shortterm"},{"points":[0.01,0.01,0.01,0.01,0.018,NaN,NaN],"variable":"longterm"},{"points":[0.03,0.038,0.04,0.04,0.064,NaN,NaN],"variable":"midterm"}],"end":"2013/08/06 22:39:50 +0000"}'
```

Probably something at an API level that needs to be fixed/handled in the raw response body, but perhaps we can gsub the response body before JSON.parse as a workaround?
