### PR TITLE
sapphire_14_08_acu164389_fix_resources_method_missing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    right_api_client (1.5.16)
+    right_api_client (1.5.17)
       json (~> 1.0)
       mime-types (~> 1.0)
       rest-client (~> 1.6)

--- a/lib/right_api_client/resources.rb
+++ b/lib/right_api_client/resources.rb
@@ -51,7 +51,8 @@ module RightApi
     # Any other method other than standard actions (create, index)
     # is simply appended to the href and called with a POST.
     def method_missing(m, *args)
-      client.send(:do_post, [ href, m.to_s ].join('/'), *args)
+      # note that 'href' method is not defined on this class; use 'path' instead.
+      client.send(:do_post, [ path, m.to_s ].join('/'), *args)
     end
   end
 end

--- a/lib/right_api_client/version.rb
+++ b/lib/right_api_client/version.rb
@@ -2,7 +2,7 @@
 module RightApi
   class Client
     API_VERSION = '1.5'
-    CLIENT_VERSION = '16'
+    CLIENT_VERSION = '17'
     VERSION = "#{API_VERSION}.#{CLIENT_VERSION}"
   end
 end


### PR DESCRIPTION
@magneland fix for RightApi::Resources#method_missing being infinitely recursive

example of bug:

> resources = client.resources(:deployments, '/api/deployments')
> resources.foo
> SystemStackError: stack level too deep
