### PR TITLE
Backward incompatible change in exception namespace change

### DIFF
--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -10,6 +10,7 @@ require File.expand_path('../resource', __FILE__)
 require File.expand_path('../resource_detail', __FILE__)
 require File.expand_path('../resources', __FILE__)
 require File.expand_path('../errors', __FILE__)
+require File.expand_path('../exceptions', __FILE__)
 
 # RightApiClient has the generic get/post/delete/put calls that are used by resources
 module RightApi


### PR DESCRIPTION
It looks like the top level namespace for exceptions is changed from `RightApi::Exceptions` to just `RightApi`. The commit 84f477907eef0a583ee5bec0ee5336309d933c75 added partial support for backward compatibility but this new module is not included by default when including `right_api_client` and the consumer code will have to include `right_api_client/exceptions` explicitly. 

To make this change completely backward compatible, the `lib/right_api_client/client.rb` should require `right_api_client/exceptions`.
