### PR TITLE
sapphire_14_10_acu166686_fixes_for_activity_service

### DIFF
--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -465,7 +465,12 @@ module RightApi
       # Update the rest client url if we are redirected to another endpoint
       uri = URI.parse(response.headers[:location])
       @api_url = "#{uri.scheme}://#{uri.host}"
-      @rest_client = RestClient::Resource.new(@api_url, :timeout => -1)
+
+      # note that the legacy code did not use the proper timeout values upon
+      # redirect (i.e. always set :timeout => -1) but that seems like an
+      # oversight; always use configured timeout values regardless of redirect.
+      @rest_client = @rest_client_class.new(
+        @api_url, :open_timeout => @open_timeout, :timeout => @timeout)
     end
   end
 end

--- a/lib/right_api_client/resource.rb
+++ b/lib/right_api_client/resource.rb
@@ -22,7 +22,7 @@ module RightApi
 
     # Data may already be 'detailed' (i.e. has a self-href) so avoid returning
     # an undetailed resource in that case. this is because calling #show on
-    # the undetailed resource would generate an redundant call to
+    # the undetailed resource would generate a redundant call to
     #   client#do_get(...)
     #
     # FIX: this logic should probably be the behavior of the Resource.process()


### PR DESCRIPTION
@magneland added Resource.process_detailed to fix case of client.resource(...) calling client.do_get(...) twice
added rest_client_class initializer parameter so that activity_service can use a different REST client implementation with better logging than RestClient::Request's default behavior.
