### PR TITLE
Set client DEFAULT_TIMEOUT to nil

### DIFF
--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -18,7 +18,7 @@ module RightApi
     include Helper
 
     DEFAULT_OPEN_TIMEOUT = nil
-    DEFAULT_TIMEOUT = -1
+    DEFAULT_TIMEOUT = nil
     DEFAULT_MAX_ATTEMPTS = 5
 
     ROOT_RESOURCE = '/api/session'


### PR DESCRIPTION
Set the client DEFAULT_TIMEOUT to nil in order to quiet "please set timeout to nil instead of -1" warning from rest_client.
