### PR TITLE
acu183852 set timeout to nil

### DIFF
--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -18,7 +18,7 @@ module RightApi
     include Helper
 
     DEFAULT_OPEN_TIMEOUT = nil
-    DEFAULT_TIMEOUT = -1
+    DEFAULT_TIMEOUT = nil
     DEFAULT_MAX_ATTEMPTS = 5
 
     ROOT_RESOURCE  = '/api/session'


### PR DESCRIPTION
Timeout was set to -1 rather than nil which was causing rest-client to throw warnings

Please see:
https://github.com/rest-client/rest-client/blob/master/lib/restclient/request.rb Line 393
