### PR TITLE
Update DEFAULT_TIMEOUT to quench warning messages

### DIFF
--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -55,7 +55,7 @@ module RightApi
     include Helper
 
     DEFAULT_OPEN_TIMEOUT = nil
-    DEFAULT_TIMEOUT = -1
+    DEFAULT_TIMEOUT = nil
     DEFAULT_MAX_ATTEMPTS = 5
 
     DEFAULT_SSL_VERSION = 'TLSv1'


### PR DESCRIPTION
When using this now, it returns this message on basically every call. 
To disable read timeouts, please set timeout to nil instead of -1

RightApi::Client::DEFAULT_TIMEOUT = nil