### PR TITLE
Right script fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 nbproject
-*login.yml
+*login*.yml
 cookies
 .loadpath
 .project

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,11 @@
 source 'https://rubygems.org'
 
 # Runtime dependencies that should appear in the gemspec.
-gem 'json', '~> 1.0'
-gem 'mime-types', '~> 1.0'
-gem 'rest-client', '~> 1.6'
+gemspec
 
 # Development dependencies that should appear in the gemspec.
 group :development do
-  gem 'rake', '0.8.7'
-  gem 'rspec', '2.9.0'
-  gem 'flexmock', '0.8.7'
-  gem 'coveralls', :require => false
+  gem 'pry'
 end
 
 # Gems used during test and development that should be OMITTED from the gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,17 @@
+PATH
+  remote: .
+  specs:
+    right_api_client (1.5.26)
+      json (~> 1.0)
+      mime-types (~> 1.0)
+      rest-client (~> 1.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.6)
     builder (3.2.2)
+    coderay (1.1.0)
     columnize (0.3.6)
     coveralls (0.7.1)
       multi_json (~> 1.3)
@@ -45,6 +54,7 @@ GEM
       multi_json (>= 1.5)
     linecache (0.46)
       rbx-require-relative (> 0.0.4)
+    method_source (0.8.2)
     mime-types (1.25.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
@@ -56,6 +66,10 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (~> 1.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.5.2)
     rake (0.8.7)
     rbx-require-relative (0.0.9)
@@ -82,6 +96,7 @@ GEM
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    slop (3.6.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
@@ -95,9 +110,8 @@ DEPENDENCIES
   debugger
   flexmock (= 0.8.7)
   jeweler (~> 2.0)
-  json (~> 1.0)
-  mime-types (~> 1.0)
+  pry
   rake (= 0.8.7)
-  rest-client (~> 1.6)
+  right_api_client!
   rspec (= 2.9.0)
   ruby-debug

--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -369,7 +369,11 @@ module RightApi
       data = if resource_type == 'text'
         { 'text' => body }
       else
-        JSON.parse(body, :allow_nan => true)
+        if res.headers[:content_type].split(';').first.strip == 'text/plain'
+          {:value => body}
+        else
+          JSON.parse(body, :allow_nan => true)
+        end
       end
 
       [resource_type, path, data]

--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -347,6 +347,8 @@ module RightApi
               # will be used later to add relevant methods to relevant resources
               type = if result.content_type.index('rightscale')
                 get_resource_type(result.content_type)
+              elsif result.content_type.index('text/plain')
+                'text'
               else
                 ''
               end
@@ -369,11 +371,7 @@ module RightApi
       data = if resource_type == 'text'
         { 'text' => body }
       else
-        if res && res.headers[:content_type].split(';').first.strip == 'text/plain'
-          {:value => body}
-        else
-          JSON.parse(body, :allow_nan => true)
-        end
+        JSON.parse(body, :allow_nan => true)
       end
 
       [resource_type, path, data]

--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -369,7 +369,7 @@ module RightApi
       data = if resource_type == 'text'
         { 'text' => body }
       else
-        if res.headers[:content_type].split(';').first.strip == 'text/plain'
+        if res && res.headers[:content_type].split(';').first.strip == 'text/plain'
           {:value => body}
         else
           JSON.parse(body, :allow_nan => true)


### PR DESCRIPTION
- Allow `GET /api/right_scripts/:id/source` to work since it comes back as `text/plain`.