### PR TITLE
IV-3008 Update do_put to add text/plain Content-type

### DIFF
--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -485,7 +485,11 @@ module RightApi
 
       begin
         retry_request do
-          @rest_client[path].put(params, headers) do |response, request, result|
+          # Altering headers to set Content-Type to text/plain when updating rightscript content
+          put_headers =
+            path =~ %r(^/api/right_scripts/.+/source$) ? headers.merge('Content-Type' => 'text/plain') : headers
+
+          @rest_client[path].put(params, put_headers) do |response, request, result|
             req, res = request, response
             update_cookies(response)
             update_last_request(request, response)

--- a/lib/right_api_client/client.rb
+++ b/lib/right_api_client/client.rb
@@ -483,12 +483,11 @@ module RightApi
 
       req, res, resource_type, body = nil
 
+      # Altering headers to set Content-Type to text/plain when updating rightscript content
+      put_headers = path =~ %r(^/api/right_scripts/.+/source$) ? headers.merge('Content-Type' => 'text/plain') : headers
+
       begin
         retry_request do
-          # Altering headers to set Content-Type to text/plain when updating rightscript content
-          put_headers =
-            path =~ %r(^/api/right_scripts/.+/source$) ? headers.merge('Content-Type' => 'text/plain') : headers
-
           @rest_client[path].put(params, put_headers) do |response, request, result|
             req, res = request, response
             update_cookies(response)


### PR DESCRIPTION
When updating RightScripts, we must set Content-type to text/plain.