### PR TITLE
Forbid rest-client 1.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Runtime dependencies that should appear in the gemspec.
 gem 'json', '~> 1.0'
 gem 'mime-types', '~> 1.0'
-gem 'rest-client', '~> 1.6'
+gem 'rest-client', '~> 1.6', '< 1.8'
 
 # Development dependencies that should appear in the gemspec.
 group :development do

--- a/right_api_client.gemspec
+++ b/right_api_client.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json>, ["~> 1.0"])
       s.add_runtime_dependency(%q<mime-types>, ["~> 1.0"])
-      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6"])
+      s.add_runtime_dependency(%q<rest-client>, ["~> 1.6", "< 1.8"])
       s.add_development_dependency(%q<rake>, ["= 0.8.7"])
       s.add_development_dependency(%q<rspec>, ["= 2.9.0"])
       s.add_development_dependency(%q<flexmock>, ["= 0.8.7"])
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
     else
       s.add_dependency(%q<json>, ["~> 1.0"])
       s.add_dependency(%q<mime-types>, ["~> 1.0"])
-      s.add_dependency(%q<rest-client>, ["~> 1.6"])
+      s.add_dependency(%q<rest-client>, ["~> 1.6", "< 1.8"])
       s.add_dependency(%q<rake>, ["= 0.8.7"])
       s.add_dependency(%q<rspec>, ["= 2.9.0"])
       s.add_dependency(%q<flexmock>, ["= 0.8.7"])
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
   else
     s.add_dependency(%q<json>, ["~> 1.0"])
     s.add_dependency(%q<mime-types>, ["~> 1.0"])
-    s.add_dependency(%q<rest-client>, ["~> 1.6"])
+    s.add_dependency(%q<rest-client>, ["~> 1.6", "< 1.8"])
     s.add_dependency(%q<rake>, ["= 0.8.7"])
     s.add_dependency(%q<rspec>, ["= 2.9.0"])
     s.add_dependency(%q<flexmock>, ["= 0.8.7"])
@@ -77,4 +77,3 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<pry>, [">= 0"])
   end
 end
-


### PR DESCRIPTION
rest-client 1.8 drops existing cookies on redirection:
<https://github.com/rest-client/rest-client/issues/406>

This means that if you use the RightScale API Client to try to log in to 'my.rightscale.com' with a session cookie from 'us-4.rightscale.com' (or vice versa), then the cookie will be dropped and you won't be able to access the API, even if the cookie is valid.