### PR TITLE
Document that api_url must be set when using a refresh_token.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ HTTP calls can sometimes fail. To enable retrying idempotent requests automatica
 Multiple accounts can be managed by using the api\_url and account\_id attributes on the client.
 
 The api\_url attribute allows users to modify the shard which the client is being used to connect to.
-This should not be required as the client will find the correct shard using the account id but is
-included for completeness.
+This should not be required as the client will find the correct shard using the account id (except
+when using a refresh\_token for authorization; in this case api\_url must be set to your shard
+address).
 
 Example:
 

--- a/config/login.yml.example
+++ b/config/login.yml.example
@@ -34,6 +34,7 @@
 # Please be careful! This is a user-specific OAuth 2.0 refresh token representing a grant with unrestricted scope.
 # Anyone who possesses it can login to RightScale's API and perform requests on this account with all of your permissions.
 # For more information, consult http://support.rightscale.com/12-Guides/03-Rightscale_API/OAuth
+# Note that api_url must be set to your shard when refresh_token is used.
 # ex: @client = RightApi::Client.new(:api_url => "https://us-x.rightscale.com", :account_id => <account_id>, :refresh_token => <token>)
 :refresh_token: my_token_string
 


### PR DESCRIPTION
The documentation was misleading in this case and it tripped me up until I figured out what was going on. Hopefully this will save others from the same confusion.

Maybe it's the API itself that's buggy, though. Other auth methods [do a redirect if you use my.rightscale.com, causing the client to correctly update its URL](https://github.com/rightscale/right_api_client/blob/9278bd542ef4457e5312abd9c07ff9fdc0a460f3/lib/right_api_client/client.rb#L296-L297). I suppose it doesn't happen in this case because when using a refresh token [the client hits `OAUTH_ENDPOINT`](https://github.com/rightscale/right_api_client/blob/9278bd542ef4457e5312abd9c07ff9fdc0a460f3/lib/right_api_client/client.rb#L273-L275) which does not include my account ID.
